### PR TITLE
fix compile on linux

### DIFF
--- a/src/antichess_tb_api.cpp
+++ b/src/antichess_tb_api.cpp
@@ -120,7 +120,7 @@ int antichess_tb_probe_dtw(const int* white_squares, const int* white_pieces, si
 		*dtw =  tb_val;
 		return (tb_dtz > 100) ? 1 : 0;
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		return -10;
 	}

--- a/src/antichess_tb_api.h
+++ b/src/antichess_tb_api.h
@@ -1,12 +1,20 @@
 #ifndef _ANTICHESS_TB_API_H_
 #define _ANTICHESS_TB_API_H_
 
+#include <stddef.h>
+
+#ifdef __cplusplus
 extern "C" {
+#endif
+
 	int antichess_tb_init();
 	int antichess_tb_add_path(const char* path, size_t path_len);
 	int antichess_tb_probe_dtw(const int* white_squares, const int* white_pieces, size_t num_white_pieces,
 	                           const int* black_squares, const int* black_pieces, size_t num_black_pieces,
 	                           int side_to_move, int ep_square, int* dtw);
-}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif

--- a/src/tb/egtb/dictzip/data.c
+++ b/src/tb/egtb/dictzip/data.c
@@ -47,6 +47,8 @@ int mmap_mode = 1; /* dictd uses mmap() function (the default) */
 int mmap_mode = 0;
 #endif
 
+int fileno(FILE *stream);
+
 static int dict_read_header(const char *filename,
 	dictData *header, int computeCRC)
 {

--- a/src/tb/egtb/dictzip/dictzip.c
+++ b/src/tb/egtb/dictzip/dictzip.c
@@ -39,6 +39,8 @@
          _a < _b ? _a : _b; })
 #endif
 
+int fileno(FILE *stream);
+
 static void xfwrite(
    const void *ptr, size_t size, size_t nmemb,
    FILE * stream)
@@ -217,7 +219,7 @@ int dict_data_zip(const char *inFilename, const char *outFilename, const char *p
 #ifdef _WIN32
 	_fstat64(fileno(inStr), &st);
 #else
-	stat(fileno(inStr), &st);
+	fstat(fileno(inStr), &st);
 #endif
 	chunks = st.st_size / chunkLength;
 	if (st.st_size % chunkLength) ++chunks;

--- a/src/tb/egtb/tb_reader.cpp
+++ b/src/tb/egtb/tb_reader.cpp
@@ -250,6 +250,8 @@ val_dtz TB_Reader::read_one(size_t key, bool is_compressed)
 		else if (val_12bit) {
 			char data[3];
 			int err = dz_read(dz_header, (unsigned long)(tbtable->header_size + i), num_bytes, data);
+			if (err != 0)
+				error("Can't read data from the file");
 			read_val_12bit(tb_bytes, key, data);
 		}
 		else {

--- a/src/tb/evaluate.cpp
+++ b/src/tb/evaluate.cpp
@@ -1617,7 +1617,7 @@ namespace {
   template<Tracing T> template<Color Us>
   Score Evaluation<T>::variant() const {
 
-    constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
+    [[maybe_unused]] constexpr Color Them = (Us == WHITE ? BLACK : WHITE);
 
     Score score = SCORE_ZERO;
 

--- a/src/tb/position.h
+++ b/src/tb/position.h
@@ -20,6 +20,7 @@
 #define POSITION_H_INCLUDED
 
 #include <cassert>
+#include <cstring> // For std::memset
 #include <deque>
 #include <memory> // For std::unique_ptr
 #include <string>


### PR DESCRIPTION
* Ensure `antichess_tb_api.h` works in pure C
* Fix compile for dictzip (that lib gives a pretty bad first expression :disappointed:)
* Fix missing include for `size_t`
* Fix missing include for `std::memset`
* Fix warnings in non-vendored code